### PR TITLE
Bug/question mark after slash

### DIFF
--- a/Robots/Models/Entry.cs
+++ b/Robots/Models/Entry.cs
@@ -82,7 +82,7 @@ namespace Robots.Model
                     type = EntryType.UserAgent;
                     entry = CreateEntry(type);
                     entry.Comment = comment;
-                    string userAgent = entryText.Substring(USER_AGENT_KEYWORD.Length).Trim().TrimEnd('?');;
+                    string userAgent = entryText.Substring(USER_AGENT_KEYWORD.Length).Trim().TrimEnd('?');
 
                     if(userAgent == null || string.IsNullOrEmpty(userAgent.Trim()))
                     {
@@ -98,7 +98,7 @@ namespace Robots.Model
                 {
                     type = EntryType.Disallow;
                     bool inverted = entryText.EndsWith("$");
-                    string value = entryText.Substring(DISALLOW_KEYWORD.Length).Trim().TrimEnd('?');
+                    string value = entryText.Substring(DISALLOW_KEYWORD.Length).Trim();
 
                     Uri url = null;
                     if (!string.IsNullOrEmpty(value) && Uri.TryCreate(baseUri, value, out url))

--- a/Robots/Robots.cs
+++ b/Robots/Robots.cs
@@ -216,7 +216,7 @@ namespace Robots
                 return true;
 
 
-            string[] uriParts = uri.LocalPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] uriParts = uri.PathAndQuery.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var disallowEntry in userAgentEntry.DisallowEntries)
             {
                 bool result;
@@ -320,7 +320,7 @@ namespace Robots
             //if (!IsInternalToDomain(uri))
             //    return true;
 
-            string[] uriParts = uri.PathAndQuery.Split(new[] {'/', '?'}, StringSplitOptions.RemoveEmptyEntries);
+            string[] uriParts = uri.PathAndQuery.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
             foreach (var allowEntry in userAgentEntry.AllowEntries)
             {
                 bool result;
@@ -336,7 +336,7 @@ namespace Robots
         private static bool CheckAllowedEntry(AllowEntry entry, string[] uriParts, out bool allow)
         {
             allow = true;
-            string[] robotInstructionUriParts = entry.Url.PathAndQuery.Split(new[] { '/', '?' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] robotInstructionUriParts = entry.Url.PathAndQuery.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
 
             if (robotInstructionUriParts.Length > uriParts.Length)
                 return false;
@@ -361,7 +361,7 @@ namespace Robots
         private static bool CheckDisallowedEntry(DisallowEntry entry, string[] uriParts, out bool allow)
         {
             allow = true;
-            string[] robotInstructionUriParts = entry.Url.PathAndQuery.Split(new[] { '/', '?' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] robotInstructionUriParts = entry.Url.PathAndQuery.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
 
             if (robotInstructionUriParts.Length > uriParts.Length)
                 return false;

--- a/RobotsTests/RobotsTest.cs
+++ b/RobotsTests/RobotsTest.cs
@@ -305,7 +305,7 @@ Disallow: /?category=another&color=red
         [TestMethod]
         public void Disallow_querystring_exact_match_not_supported_Test()
         {
-            Assert.IsTrue(RobotsContentWithQuerystringOnRoot.Allowed(BASE_URL + "?category=whatever", "googlebot"));
+            Assert.IsFalse(RobotsContentWithQuerystringOnRoot.Allowed(BASE_URL + "?category=whatever", "googlebot"));
         }
 
         [TestMethod]
@@ -320,6 +320,26 @@ Disallow: /?category=another&color=red
         {
             bool actual = RobotsWildcards.Allowed("/a/public/c/");
             Assert.AreEqual(true, actual);
+        }
+
+        [TestMethod]
+        public void Allow_QuestionMarkAfterSlashTest_DisallowOnlyWhenTheQuestionMarkIsRightAfterTheSlash()
+        {
+            var robots = new Robots.Robots();
+            robots.LoadContent(
+                @"User-Agent: *
+Disallow: /?
+Disallow: /disallowfolder/?private
+Allow: /?public/public"
+                ,BaseUrl
+            );
+
+            Assert.IsFalse(robots.Allowed("/?blablabla"));
+            Assert.IsTrue(robots.Allowed("/blablabla/blabla"));
+            Assert.IsTrue(robots.Allowed("/blablabla/?blabla"));
+            Assert.IsTrue(robots.Allowed("/blab?labla"));
+            Assert.IsFalse(robots.Allowed("/disallowfolder/?private"));
+            Assert.IsTrue(robots.Allowed("/?public/public"));
         }
 
         [TestMethod]
@@ -498,7 +518,6 @@ Disallow: /?category=another&color=red
         [TestMethod]
         public void Sitemap_NoSitemapValueInRobotsDotText_ReturnEmptyCollection()
         {
-
             Assert.AreEqual(0, RobotsEmpty.GetSitemapUrls().Count);
         }
     }


### PR DESCRIPTION
Thank you for a great library, I want to fix the following bug:
`Disallow: /?` is parsed to "Disallow All" role on this library.
You can see this bug on [https://www.autoscout24.fr/robots.txt](https://www.autoscout24.fr/robots.txt) for example.
According to Google robots.txt parser logic ([https://github.com/google/robotstxt](https://github.com/google/robotstxt)), it's need to block only urls with '?' right after '/'.
I fixed this issue and add unit test for this case. In addition, I fix a wrong test case.